### PR TITLE
Fix tar path traversal through symlinks

### DIFF
--- a/tar_test.go
+++ b/tar_test.go
@@ -1,13 +1,23 @@
 package archiver_test
 
 import (
+	"archive/tar"
+	"bytes"
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/mholt/archiver/v3"
 )
+
+func requireDoesNotExist(t *testing.T, path string) {
+	_, err := os.Stat(path)
+	if err == nil {
+		t.Fatalf("'%s' expected to not exist", path)
+	}
+}
 
 func requireRegularFile(t *testing.T, path string) os.FileInfo {
 	fileInfo, err := os.Stat(path)
@@ -45,6 +55,68 @@ func TestDefaultTar_Unarchive_HardlinkSuccess(t *testing.T) {
 	fileaInfo := requireRegularFile(t, path.Join(destination, "dir-1", "dir-2", "file-a"))
 	filebInfo := requireRegularFile(t, path.Join(destination, "dir-1", "dir-2", "file-b"))
 	assertSameFile(t, fileaInfo, filebInfo)
+}
+
+func TestDefaultTar_Unarchive_SymlinkPathTraversal(t *testing.T) {
+	tmp := t.TempDir()
+	source := filepath.Join(tmp, "source.tar")
+	createSymlinkPathTraversalSample(t, source)
+	destination := filepath.Join(tmp, "destination")
+
+	err := archiver.DefaultTar.Unarchive(source, destination)
+	if err != nil {
+		t.Fatalf("unarchiving '%s' to '%s': %v", source, destination, err)
+	}
+
+	requireDoesNotExist(t, filepath.Join(tmp, "target"))
+	requireRegularFile(t, filepath.Join(tmp, "destination", "symlinkvehicle.txt"))
+}
+
+func createSymlinkPathTraversalSample(t *testing.T, archivePath string) {
+	t.Helper()
+
+	type tarinfo struct {
+		Name string
+		Link string
+		Body string
+		Type byte
+	}
+
+	var infos = []tarinfo{
+		{"symlinkvehicle.txt", "./../target", "", tar.TypeSymlink},
+		{"symlinkvehicle.txt", "", "content modified!", tar.TypeReg},
+	}
+
+	var buf bytes.Buffer
+	var tw = tar.NewWriter(&buf)
+	for _, ti := range infos {
+		hdr := &tar.Header{
+			Name:     ti.Name,
+			Mode:     0600,
+			Linkname: ti.Link,
+			Typeflag: ti.Type,
+			Size:     int64(len(ti.Body)),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal("Writing header: ", err)
+		}
+		if _, err := tw.Write([]byte(ti.Body)); err != nil {
+			t.Fatal("Writing body: ", err)
+		}
+	}
+
+	f, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = f.Write(buf.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestDefaultTar_Extract_HardlinkSuccess(t *testing.T) {


### PR DESCRIPTION
There are already protections in place to prevent writing files outside of the unarchive directory. This PR extends these protections to include symlink destinations; if a symlink points to a location outside of the unarchive destination then this will now result in an error.  This covers two cases:
- when there is symlink destination that is a relative path pointing outside of the unarchive destination
- when there is symlink destination that is an absolute path existing outside of the unarchive destination

This patches [CVE-2024-0406](https://nvd.nist.gov/vuln/detail/CVE-2024-0406).